### PR TITLE
Update fix serialization to include args

### DIFF
--- a/src/main/java/edu/ucr/cs/riple/taint/ucrtainting/serialization/Error.java
+++ b/src/main/java/edu/ucr/cs/riple/taint/ucrtainting/serialization/Error.java
@@ -3,6 +3,9 @@ package edu.ucr.cs.riple.taint.ucrtainting.serialization;
 import com.google.common.collect.ImmutableSet;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
+
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.json.JSONArray;
@@ -13,8 +16,8 @@ public class Error implements JSONSerializable {
 
   /** Message key for the error. */
   public final String messageKey;
-  /** Message for the error. */
-  public final String message;
+  /** Args for message construction */
+  public final Object[] args;
   /**
    * Set of fixes that can resolve the error. If the error is not fixable, this set will be empty.
    */
@@ -31,9 +34,9 @@ public class Error implements JSONSerializable {
    */
   @Nullable public final Symbol regionSymbol;
 
-  public Error(String messageKey, String message, Set<Fix> resolvingFixes, TreePath path) {
+  public Error(String messageKey, Object[] args, Set<Fix> resolvingFixes, TreePath path) {
     this.messageKey = messageKey;
-    this.message = message;
+    this.args = args;
     this.resolvingFixes = ImmutableSet.copyOf(resolvingFixes);
     this.regionClass = Utility.findRegionClassSymbol(path);
     this.regionSymbol = Utility.findRegionMemberSymbol(this.regionClass, path);
@@ -43,7 +46,7 @@ public class Error implements JSONSerializable {
   public JSONObject toJSON() {
     JSONObject ans = new JSONObject();
     ans.put("messageKey", messageKey);
-    ans.put("message", message);
+    ans.put("args", new JSONArray(Arrays.stream(args).map(Objects::toString).toArray()));
     JSONObject region = new JSONObject();
     region.put("class", Serializer.serializeSymbol(regionClass));
     region.put("symbol", Serializer.serializeSymbol(regionSymbol));

--- a/src/main/java/edu/ucr/cs/riple/taint/ucrtainting/serialization/SerializationService.java
+++ b/src/main/java/edu/ucr/cs/riple/taint/ucrtainting/serialization/SerializationService.java
@@ -49,7 +49,7 @@ public class SerializationService {
             : ImmutableSet.of();
     Error error =
         new Error(
-            messageKey, String.format(messageKey, args), resolvingFixes, visitor.getCurrentPath());
+            messageKey, args, resolvingFixes, visitor.getCurrentPath());
     serializer.serializeError(error);
   }
 


### PR DESCRIPTION
This PR replaces `message` field in serialization with args used to construct the message. Eventually we will need to parse message to extract args, we can serialize the directly. 