### PR TITLE
Add access-path tests

### DIFF
--- a/src/test/java/tests/AccessPathTest.java
+++ b/src/test/java/tests/AccessPathTest.java
@@ -1,0 +1,32 @@
+package tests;
+
+import edu.ucr.cs.riple.taint.ucrtainting.UCRTaintingChecker;
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test runner for tests of the UCR Tainting Checker.
+ *
+ * <p>Tests appear as Java files in the {@code tests/ucrtainting} folder. To add a new test case,
+ * create a Java file in that directory. The file contains "// ::" comments to indicate expected
+ * errors and warnings; see
+ * https://github.com/typetools/checker-framework/blob/master/checker/tests/README .
+ */
+public class AccessPathTest extends CheckerFrameworkPerDirectoryTest {
+    public AccessPathTest(List<File> testFiles) {
+        super(
+                testFiles,
+                UCRTaintingChecker.class,
+                "ucrtainting",
+                "-Anomsgtext",
+                "-Astubs=stubs/",
+                "-nowarn");
+    }
+
+    @Parameterized.Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"accesspath"};
+    }
+}

--- a/src/test/java/tests/AccessPathTest.java
+++ b/src/test/java/tests/AccessPathTest.java
@@ -15,18 +15,18 @@ import org.junit.runners.Parameterized;
  * https://github.com/typetools/checker-framework/blob/master/checker/tests/README .
  */
 public class AccessPathTest extends CheckerFrameworkPerDirectoryTest {
-    public AccessPathTest(List<File> testFiles) {
-        super(
-                testFiles,
-                UCRTaintingChecker.class,
-                "ucrtainting",
-                "-Anomsgtext",
-                "-Astubs=stubs/",
-                "-nowarn");
-    }
+  public AccessPathTest(List<File> testFiles) {
+    super(
+        testFiles,
+        UCRTaintingChecker.class,
+        "ucrtainting",
+        "-Anomsgtext",
+        "-Astubs=stubs/",
+        "-nowarn");
+  }
 
-    @Parameterized.Parameters
-    public static String[] getTestDirs() {
-        return new String[] {"accesspath"};
-    }
+  @Parameterized.Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"accesspath"};
+  }
 }

--- a/tests/accesspath/Test.java
+++ b/tests/accesspath/Test.java
@@ -1,0 +1,19 @@
+import edu.ucr.cs.riple.taint.ucrtainting.qual.*;
+import java.util.*;
+
+public class Test{
+
+    public HashMap<String, String> foo;
+    Inner inner;
+
+    void bar(){
+        // :: error: assignment
+        @RUntainted String a = foo.keySet().iterator().next();
+        // :: error: assignment
+        @RUntainted String b = inner.bar.keySet().iterator().next();
+    }
+
+    class Inner{
+        public HashMap<String, String> bar;
+    }
+}

--- a/tests/accesspath/Test.java
+++ b/tests/accesspath/Test.java
@@ -3,7 +3,7 @@ import java.util.*;
 
 public class Test {
 
-  public HashMap<String, String> foo;
+  HashMap<String, String> foo;
   Inner inner;
 
   void bar() {
@@ -11,9 +11,13 @@ public class Test {
     @RUntainted String a = foo.keySet().iterator().next();
     // :: error: assignment
     @RUntainted String b = inner.bar.keySet().iterator().next();
+    // :: error: assignment
+    @RUntainted String c = inner.test.foo.keySet().iterator().next();
   }
 
   class Inner {
-    public HashMap<String, String> bar;
+
+    HashMap<String, String> bar;
+    Test test;
   }
 }

--- a/tests/accesspath/Test.java
+++ b/tests/accesspath/Test.java
@@ -1,19 +1,19 @@
 import edu.ucr.cs.riple.taint.ucrtainting.qual.*;
 import java.util.*;
 
-public class Test{
+public class Test {
 
-    public HashMap<String, String> foo;
-    Inner inner;
+  public HashMap<String, String> foo;
+  Inner inner;
 
-    void bar(){
-        // :: error: assignment
-        @RUntainted String a = foo.keySet().iterator().next();
-        // :: error: assignment
-        @RUntainted String b = inner.bar.keySet().iterator().next();
-    }
+  void bar() {
+    // :: error: assignment
+    @RUntainted String a = foo.keySet().iterator().next();
+    // :: error: assignment
+    @RUntainted String b = inner.bar.keySet().iterator().next();
+  }
 
-    class Inner{
-        public HashMap<String, String> bar;
-    }
+  class Inner {
+    public HashMap<String, String> bar;
+  }
 }


### PR DESCRIPTION
This PR adds some unit regarding correct processing of access paths.

See example below:

```java
@RUntainted String a = foo.keySet().iterator().next();
```

Here we should identify `foo` as the element to be annotated with `@RUntainted`

And

```java
@RUntainted String c = inner.test.foo.keySet().iterator().next();
```

we should again identify `foo` as the element to be annotated with `@RUntainted`